### PR TITLE
Add support for a Jekyll theme

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+fp.michalspano.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+remote_theme: niklasbuschmann/contrast@v2.11
+
+plugins:
+  - jekyll-remote-theme
+
+# accepts {file, title, url, icon, sidebaricon}
+navigation: 
+  - {file: "README.md"}

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,14 @@
-## *fp.michalspano.com* ~ My take on Functional Programming
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Lambda_lc.svg/2048px-Lambda_lc.svg.png"
+     width="150px" height="150px" align="left"
+/>
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Lambda_lc.svg/2048px-Lambda_lc.svg.png" width="150px" height="150px" align="left">
-
-At this __subdomain__, I plan to post about my take on Functional Programming. Recently, I've emerged myself into this __paradigm__ and I've grew thoroughly fond of it. Therefore, I want to share my thoughts and ideas about it, as well as my own implementations of some of the most popular __algorithms__ and __data structures__ – to show, that __FP__ is not only about __pure functions__ and __immutable data__ – it's also about another way of thinking and approaching problems.
+I plan to post about my take on Functional Programming on this subdomain. I've
+emerged myself into this __paradigm__ and I grew thoroughly fond of it.
+Therefore, I want to share my thoughts and ideas about it, as well as my own
+implementations of some of the most popular __algorithms__, __data
+structures__, and so forth -- to show, that __FP__ is not only about __pure
+functions__ and __immutable data__ – it's also about another way of thinking
+and approaching problems.
 
 ### Table of Contents
 


### PR DESCRIPTION
Chosen theme: [github.com/niklasbuschmann](https://github.com/niklasbuschmann/contrast); a minimal "blog" that supports code snippets and mathematical expressions with `KaTeX`.

Closes #1